### PR TITLE
feat: Implement dedup command (#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,13 @@
 name = "wistra"
 version = "0.1.0"
 edition = "2021"
+authors = ["0010capacity"]
 description = "AI-powered personal wiki builder"
 license = "MIT"
+repository = "https://github.com/0010capacity/wistra"
+readme = "README.md"
+keywords = ["wiki", "ai", "markdown", "cli", "knowledge-graph"]
+categories = ["command-line-utilities", "text-processing"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,123 @@
+# wistra
+
+AI-powered personal wiki builder. Scans a knowledge graph, fills stub concepts, resolves disambiguation, and keeps everything connected — entirely from the command line.
+
+## Installation
+
+```bash
+cargo install wistra
+```
+
+## Quick Start
+
+```bash
+# Initial setup (configure API key, wiki path, interests)
+wistra onboard
+
+# Grow your wiki with AI-generated content
+wistra run
+
+# Scan and see wiki statistics
+wistra scan
+
+# Start a local web server to browse your wiki
+wistra serve
+```
+
+## Commands
+
+### Core
+
+| Command | Description |
+|---------|-------------|
+| `wistra onboard` | Run the setup wizard |
+| `wistra run` | Grow the wiki with AI-generated concepts |
+| `wistra scan` | Scan wiki and print detailed report |
+| `wistra status` | Print compact status summary |
+| `wistra serve` | Start HTTP server to browse wiki |
+
+### Document Management
+
+| Command | Description |
+|---------|-------------|
+| `wistra rename <old> <new>` | Rename a document and update all links |
+| `wistra merge <source> <target>` | Merge two documents |
+| `wistra delete <title>` | Delete a document and clean up links |
+| `wistra import <path>` | Import external markdown files |
+
+### Analysis
+
+| Command | Description |
+|---------|-------------|
+| `wistra backlinks <title>` | Show documents linking to a document |
+| `wistra orphans` | Find documents with no incoming links |
+| `wistra search <query>` | Full-text search across documents |
+| `wistra graph <title>` | Show document connection graph |
+| `wistra stats [type]` | Extended statistics (basic, trends, tags, links) |
+| `wistra dedup` | Detect duplicate or similar documents |
+| `wistra clean` | Detect and fix wiki technical debt |
+
+### Tags
+
+| Command | Description |
+|---------|-------------|
+| `wistra tags list` | List all tags with document counts |
+| `wistra tags rename <old> <new>` | Rename a tag across all documents |
+| `wistra tags merge <source> <target>` | Merge tags |
+| `wistra tags orphans` | Find unused tags |
+
+### Configuration
+
+| Command | Description |
+|---------|-------------|
+| `wistra config` | Modify configuration |
+| `wistra interests` | Modify interest domains |
+
+## Wiki Format
+
+Wistra uses standard Markdown with YAML frontmatter:
+
+```markdown
+---
+title: Concept Name
+aliases: ["Alternative Name"]
+tags: ["category/subcategory"]
+status: published
+created: 2024-01-15
+---
+
+# Concept Name
+
+Content goes here. Link to other concepts with [[Wikilinks]].
+
+You can also use [[Target|display text]].
+```
+
+### Status Values
+
+- `published` — Complete document
+- `stub` — Placeholder waiting for content
+- `disambiguation` — Disambiguation page
+- `meta` — Index/meta document
+
+## Configuration
+
+Global configuration is stored at `~/.wistra/config.toml`:
+
+```toml
+claude_api_key = "sk-ant-..."
+wiki_path = "~/wiki"
+language = "en"
+interests = ["computer-science", "philosophy"]
+```
+
+Per-wiki configuration is stored at `<wiki>/.wistra/config.toml`.
+
+## Requirements
+
+- Rust 1.70+
+- Claude API key (for AI-powered features)
+
+## License
+
+MIT

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -268,6 +268,21 @@ pub enum Commands {
         #[arg(short, long)]
         open: bool,
     },
+
+    /// Detect duplicate or similar documents
+    Dedup {
+        /// Path to wiki directory
+        #[arg(default_value = ".")]
+        path: String,
+
+        /// Similarity threshold for fuzzy matching (0.0-1.0)
+        #[arg(long, default_value = "0.8")]
+        threshold: f64,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,9 @@ async fn main() -> Result<()> {
         Some(cli::Commands::Serve { path, port, host, open }) => {
             serve::serve(&path, &host, port, open).await?;
         }
+        Some(cli::Commands::Dedup { path, threshold, json }) => {
+            run_dedup(&path, threshold, json)?;
+        }
     }
 
     Ok(())
@@ -1459,4 +1462,151 @@ fn update_state(
     std::fs::write(wiki_config.state_path(), json)?;
 
     Ok(())
+}
+
+/// Run the dedup command - detect duplicate or similar documents
+fn run_dedup(path: &str, threshold: f64, json: bool) -> Result<()> {
+    use std::collections::HashMap;
+    use strsim::normalized_levenshtein;
+
+    let path = shellexpand::tilde(path).to_string();
+    let wiki_path = PathBuf::from(path);
+    let wiki_config = config::WikiConfig::load(&wiki_path)?;
+    let report = scanner::scan_wiki(&wiki_config)?;
+
+    // Collect non-meta documents
+    let docs: Vec<&types::Document> = report.documents
+        .values()
+        .filter(|doc| doc.status != types::Status::Meta)
+        .collect();
+
+    // 1. Detect similar titles (fuzzy match)
+    let mut similar_titles: Vec<(String, String, f64)> = Vec::new();
+    for i in 0..docs.len() {
+        for j in (i + 1)..docs.len() {
+            let title_a = normalize_for_comparison(&docs[i].title);
+            let title_b = normalize_for_comparison(&docs[j].title);
+
+            // Skip if titles are identical (exact duplicates)
+            if title_a == title_b {
+                continue;
+            }
+
+            let score = normalized_levenshtein(&title_a, &title_b);
+            if score >= threshold {
+                similar_titles.push((
+                    docs[i].title.clone(),
+                    docs[j].title.clone(),
+                    score,
+                ));
+            }
+        }
+    }
+
+    // Sort by similarity score (highest first)
+    similar_titles.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+
+    // 2. Detect documents with duplicate aliases
+    let mut alias_map: HashMap<String, Vec<String>> = HashMap::new();
+    for doc in &docs {
+        for alias in &doc.aliases {
+            let alias_lower = alias.to_lowercase();
+            alias_map.entry(alias_lower)
+                .or_insert_with(Vec::new)
+                .push(doc.title.clone());
+        }
+    }
+    let duplicate_aliases: Vec<(String, Vec<String>)> = alias_map
+        .into_iter()
+        .filter(|(_, titles)| titles.len() > 1)
+        .collect();
+
+    // 3. Report orphaned stubs that reference same concept
+    let stub_groups: HashMap<String, Vec<String>> = report.stub_candidates
+        .iter()
+        .map(|stub| {
+            let target_lower = stub.target.to_lowercase();
+            (target_lower, vec![stub.target.clone()])
+        })
+        .fold(HashMap::new(), |mut acc, (key, val)| {
+            acc.entry(key).or_insert_with(Vec::new).extend(val);
+            acc
+        });
+
+    let orphaned_stubs: Vec<(String, usize)> = stub_groups
+        .into_iter()
+        .map(|(key, targets)| (key, targets.len()))
+        .collect();
+
+    // Output results
+    if json {
+        let output = serde_json::json!({
+            "similar_titles": similar_titles.iter().map(|(a, b, score)| serde_json::json!({
+                "title_a": a,
+                "title_b": b,
+                "similarity": score
+            })).collect::<Vec<_>>(),
+            "duplicate_aliases": duplicate_aliases.iter().map(|(alias, titles)| serde_json::json!({
+                "alias": alias,
+                "documents": titles
+            })).collect::<Vec<_>>(),
+            "orphaned_stubs": orphaned_stubs.iter().map(|(target, count)| serde_json::json!({
+                "target": target,
+                "stub_count": count
+            })).collect::<Vec<_>>(),
+            "summary": {
+                "similar_titles_count": similar_titles.len(),
+                "duplicate_aliases_count": duplicate_aliases.len(),
+                "orphaned_stubs_count": orphaned_stubs.len()
+            }
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("🔍 Duplicate Detection Report");
+        println!();
+
+        // Similar titles
+        if similar_titles.is_empty() {
+            println!("✅ Similar titles: none");
+        } else {
+            println!("⚠️  Similar titles (fuzzy match ≥ {:.0}%):", threshold * 100.0);
+            for (a, b, score) in &similar_titles {
+                println!("   [[{}]] ↔ [[{}]] ({:.0}%)", a, b, score * 100.0);
+            }
+        }
+        println!();
+
+        // Duplicate aliases
+        if duplicate_aliases.is_empty() {
+            println!("✅ Duplicate aliases: none");
+        } else {
+            println!("⚠️  Duplicate aliases:");
+            for (alias, titles) in &duplicate_aliases {
+                println!("   \"{}\" used by: {}", alias, titles.iter().map(|t| format!("[[{}]]", t)).collect::<Vec<_>>().join(", "));
+            }
+        }
+        println!();
+
+        // Orphaned stubs
+        if orphaned_stubs.is_empty() {
+            println!("✅ Orphaned stubs: none");
+        } else {
+            println!("⚠️  Orphaned stubs (unresolved links):");
+            for (target, count) in &orphaned_stubs {
+                println!("   [[{}]] ({} references)", target, count);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Normalize a string for comparison (lowercase, alphanumeric only)
+fn normalize_for_comparison(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+        .collect::<String>()
+        .trim()
+        .to_string()
 }


### PR DESCRIPTION
## Summary
- Implement `dedup` command to detect duplicate or similar documents
- Uses normalized Levenshtein distance for fuzzy title matching
- Detects documents with duplicate aliases
- Reports orphaned stubs that reference the same concept
- Supports text (default) and JSON output formats
- Dry-run only (no auto-actions)

## Test plan
- [x] `wistra dedup --help` shows correct usage
- [x] `wistra dedup` runs without errors
- [x] `wistra dedup --json` outputs valid JSON
- [x] Similar titles are detected with fuzzy matching
- [x] Duplicate aliases are detected
- [x] Orphaned stubs are reported

Closes #11